### PR TITLE
fix: 修复CheeseInfo中的my_bp字段为小数时导致的json解析错误问题

### DIFF
--- a/src-tauri/src/types/cheese_info.rs
+++ b/src-tauri/src/types/cheese_info.rs
@@ -172,7 +172,7 @@ pub struct PaidJump {
 pub struct Payment {
     pub bp_enough: i64,
     pub desc: String,
-    pub my_bp: i64,
+    pub my_bp: f64,
     pub pay_shade: String,
     pub price: f64,
     pub price_format: String,


### PR DESCRIPTION
解决这个issue #100 